### PR TITLE
fix: validate Qiita tag counts before publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ platform: auto
 Body...
 ```
 
-- `tags`: Accepts an array or a comma-separated string.
+- `tags`: Accepts an array or a comma-separated string. Qiita enforces between 1 and 5 tags per article, so keep your list withi
+n that range when targeting Qiita.
 - `platform`: Omit or set to `auto` to target both platforms. Include `devto` or `qiita` to limit publishing.
 - `qiita_org`: Optional Qiita group identifier for organizational posts.
 - dev.to-specific keys such as `canonical_url`, `cover_image`, `series`, and `organization_id` are supported.

--- a/scripts/publish_qiita.ts
+++ b/scripts/publish_qiita.ts
@@ -162,6 +162,13 @@ const main = async (): Promise<void> => {
     }
 
     const tags = ensureArrayOfStrings(frontMatter.tags);
+    if (!tags || tags.length < 1 || tags.length > 5) {
+      console.error(
+        `Error: ${relativePath} - Qiita requires between 1 and 5 tags; found ${tags ? tags.length : 0}. Update the front matter and try again.`,
+      );
+      process.exitCode = 1;
+      continue;
+    }
 
     const itemPayload = {
       title: frontMatter.title,


### PR DESCRIPTION
## Summary
- validate Qiita tag inputs and abort the run when they fall outside Qiita's 1-5 tag requirement
- document the enforced Qiita tag limit so authors know how many tags they can use

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7df527e888326926e9fa202b5959a