### PR TITLE
fix: prune stale post map entries when drafts are skipped

### DIFF
--- a/scripts/publish_devto.ts
+++ b/scripts/publish_devto.ts
@@ -117,12 +117,16 @@ const main = async (): Promise<void> => {
 
   for (const fileArg of fileArgs) {
     const absolutePath = path.resolve(fileArg);
+    const relativePath = path.relative(process.cwd(), absolutePath);
+
     if (!fs.existsSync(absolutePath)) {
+      if (postMap[relativePath]) {
+        delete postMap[relativePath];
+        console.log(`Removed stale dev.to mapping for ${relativePath} (file not found)`);
+      }
       console.warn(`Skipped: ${fileArg} (file not found)`);
       continue;
     }
-
-    const relativePath = path.relative(process.cwd(), absolutePath);
     const rawMarkdown = fs.readFileSync(absolutePath, 'utf-8');
     const parsed = matter(rawMarkdown);
     const frontMatter = parsed.data as FrontMatter;
@@ -133,6 +137,10 @@ const main = async (): Promise<void> => {
     }
 
     if (!wantsDevTo(frontMatter.platform)) {
+      if (postMap[relativePath]) {
+        delete postMap[relativePath];
+        console.log(`Removed stale dev.to mapping for ${relativePath} (platform excludes dev.to)`);
+      }
       console.log(`Skipped: ${relativePath} (platform excludes dev.to)`);
       continue;
     }

--- a/scripts/publish_qiita.ts
+++ b/scripts/publish_qiita.ts
@@ -122,12 +122,16 @@ const main = async (): Promise<void> => {
 
   for (const fileArg of fileArgs) {
     const absolutePath = path.resolve(fileArg);
+    const relativePath = path.relative(process.cwd(), absolutePath);
+
     if (!fs.existsSync(absolutePath)) {
+      if (postMap[relativePath]) {
+        delete postMap[relativePath];
+        console.log(`Removed stale Qiita mapping for ${relativePath} (file not found)`);
+      }
       console.warn(`Skipped: ${fileArg} (file not found)`);
       continue;
     }
-
-    const relativePath = path.relative(process.cwd(), absolutePath);
     const rawMarkdown = fs.readFileSync(absolutePath, 'utf-8');
     const parsed = matter(rawMarkdown);
     const frontMatter = parsed.data as FrontMatter;
@@ -138,6 +142,10 @@ const main = async (): Promise<void> => {
     }
 
     if (!wantsQiita(frontMatter.platform)) {
+      if (postMap[relativePath]) {
+        delete postMap[relativePath];
+        console.log(`Removed stale Qiita mapping for ${relativePath} (platform excludes Qiita)`);
+      }
       console.log(`Skipped: ${relativePath} (platform excludes Qiita)`);
       continue;
     }


### PR DESCRIPTION
## Summary
- remove stale dev.to and Qiita IDs when inputs are skipped
- keep post maps in sync when files are missing or platforms change

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7df52f4ac8326b232562f1b78d43e