### PR TITLE
ci: enforce remote article sync before merging

### DIFF
--- a/.github/workflows/verify-map-sync.yml
+++ b/.github/workflows/verify-map-sync.yml
@@ -1,0 +1,37 @@
+name: Verify article sync
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  verify:
+    name: Remote content synchronization
+    if: >-
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref ==
+      (vars.SYNC_BRANCH_NAME != '' && vars.SYNC_BRANCH_NAME || 'sync/articles')
+    runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: ${{ vars.SYNC_BRANCH_NAME != '' && vars.SYNC_BRANCH_NAME || 'sync/articles' }}
+      DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
+      QIITA_TOKEN: ${{ secrets.QIITA_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Display targeted branch
+        run: echo "Enforcing sync verification for branch '${TARGET_BRANCH}'"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify remote content matches post maps
+        run: npx ts-node scripts/verify_remote_sync.ts

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Each run updates the corresponding `.posts-map.*.json` file with the latest remo
 
 GitHub Actions workflows previously handled publishing on pushes to `main`, but the automation has been retired. Keep using the Make targets locally (or wire them into a different CI/CD system) to manage publication.
 
+#### Remote sync enforcement
+
+The `Verify article sync` workflow blocks merges when a synchronization branch targets `main` but remote articles are out of date.
+
+- By default the workflow watches for pull requests whose head branch is `sync/articles`. You can override the branch name by defining a repository variable called `SYNC_BRANCH_NAME`.
+- The check runs `scripts/verify_remote_sync.ts`, which confirms that the markdown content and titles for every entry in `.posts-map.devto.json` and `.posts-map.qiita.json` match their respective remote articles. It also validates that stored URLs, publish flags, and timestamps are in sync.
+- Repository secrets named `DEVTO_API_KEY` and `QIITA_TOKEN` are required so the script can query private drafts.
+
 ## Operational Tips
 
 - Run `npm run lint` before opening a PR to ensure the scripts pass TypeScript checks.

--- a/scripts/verify_remote_sync.ts
+++ b/scripts/verify_remote_sync.ts
@@ -1,0 +1,236 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import fetch from 'node-fetch';
+
+type DevToArticle = {
+  id: number;
+  title: string;
+  body_markdown: string;
+  url?: string;
+  published: boolean;
+  updated_at?: string;
+};
+
+type QiitaItem = {
+  id: string;
+  title: string;
+  body: string;
+  url?: string;
+  private: boolean;
+  updated_at?: string;
+};
+
+type PostMapEntry = {
+  id: number | string;
+  url?: string;
+  updatedAt?: string;
+  published?: boolean;
+};
+
+type PostMap = Record<string, PostMapEntry>;
+
+type VerificationError = {
+  file: string;
+  message: string;
+};
+
+const DEVTO_API_BASE = 'https://dev.to/api/articles';
+const QIITA_API_BASE = 'https://qiita.com/api/v2/items';
+
+const normalize = (value: string): string => value.replace(/\r\n/g, '\n').trim();
+
+const loadPostMap = (mapPath: string): PostMap => {
+  try {
+    const raw = fs.readFileSync(mapPath, 'utf-8');
+    return JSON.parse(raw) as PostMap;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+};
+
+const readLocalArticle = (relativePath: string): { title: string; content: string } => {
+  const absolutePath = path.resolve(relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Local file ${relativePath} referenced in map is missing.`);
+  }
+  const raw = fs.readFileSync(absolutePath, 'utf-8');
+  const parsed = matter(raw);
+  const title = typeof parsed.data.title === 'string' ? parsed.data.title : '';
+  const content = normalize(parsed.content);
+  return { title, content };
+};
+
+const fetchDevToArticle = async (id: number, token: string): Promise<DevToArticle> => {
+  const response = await fetch(`${DEVTO_API_BASE}/${id}`, {
+    headers: {
+      'api-key': token,
+      'User-Agent': 'article-sync-verifier'
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to fetch dev.to article ${id}: ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  return (await response.json()) as DevToArticle;
+};
+
+const fetchQiitaItem = async (id: string, token: string): Promise<QiitaItem> => {
+  const response = await fetch(`${QIITA_API_BASE}/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'article-sync-verifier'
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to fetch Qiita item ${id}: ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  return (await response.json()) as QiitaItem;
+};
+
+const verifyDevToEntries = async (map: PostMap, token: string): Promise<VerificationError[]> => {
+  const errors: VerificationError[] = [];
+
+  for (const [relativePath, entry] of Object.entries(map)) {
+    try {
+      const local = readLocalArticle(relativePath);
+      const article = await fetchDevToArticle(Number(entry.id), token);
+
+      if (normalize(article.body_markdown) !== local.content) {
+        errors.push({
+          file: relativePath,
+          message: 'Local markdown content does not match remote dev.to article. Run the publish script to sync it.'
+        });
+      }
+
+      if (article.title.trim() !== local.title.trim()) {
+        errors.push({
+          file: relativePath,
+          message: 'Local title does not match remote dev.to article title.'
+        });
+      }
+
+      if (typeof entry.published === 'boolean' && entry.published !== article.published) {
+        errors.push({
+          file: relativePath,
+          message: 'Stored published flag for dev.to entry is out of sync with remote state.'
+        });
+      }
+
+      if (entry.url && article.url && entry.url !== article.url) {
+        errors.push({
+          file: relativePath,
+          message: 'Stored dev.to URL differs from remote URL.'
+        });
+      }
+
+      if (entry.updatedAt && article.updated_at && entry.updatedAt !== article.updated_at) {
+        errors.push({
+          file: relativePath,
+          message: 'Stored dev.to updatedAt differs from remote updated_at timestamp.'
+        });
+      }
+    } catch (error) {
+      errors.push({ file: relativePath, message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  return errors;
+};
+
+const verifyQiitaEntries = async (map: PostMap, token: string): Promise<VerificationError[]> => {
+  const errors: VerificationError[] = [];
+
+  for (const [relativePath, entry] of Object.entries(map)) {
+    try {
+      const local = readLocalArticle(relativePath);
+      const item = await fetchQiitaItem(String(entry.id), token);
+
+      if (normalize(item.body) !== local.content) {
+        errors.push({
+          file: relativePath,
+          message: 'Local markdown content does not match remote Qiita article. Run the publish script to sync it.'
+        });
+      }
+
+      if (item.title.trim() !== local.title.trim()) {
+        errors.push({
+          file: relativePath,
+          message: 'Local title does not match remote Qiita article title.'
+        });
+      }
+
+      const remotePublished = !item.private;
+      if (typeof entry.published === 'boolean' && entry.published !== remotePublished) {
+        errors.push({
+          file: relativePath,
+          message: 'Stored published flag for Qiita entry is out of sync with remote state.'
+        });
+      }
+
+      if (entry.url && item.url && entry.url !== item.url) {
+        errors.push({
+          file: relativePath,
+          message: 'Stored Qiita URL differs from remote URL.'
+        });
+      }
+
+      if (entry.updatedAt && item.updated_at && entry.updatedAt !== item.updated_at) {
+        errors.push({
+          file: relativePath,
+          message: 'Stored Qiita updatedAt differs from remote updated_at timestamp.'
+        });
+      }
+    } catch (error) {
+      errors.push({ file: relativePath, message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  return errors;
+};
+
+const main = async (): Promise<void> => {
+  const devToToken = process.env.DEVTO_API_KEY;
+  const qiitaToken = process.env.QIITA_TOKEN;
+
+  if (!devToToken) {
+    throw new Error('DEVTO_API_KEY is not set.');
+  }
+  if (!qiitaToken) {
+    throw new Error('QIITA_TOKEN is not set.');
+  }
+
+  const devToMap = loadPostMap('.posts-map.devto.json');
+  const qiitaMap = loadPostMap('.posts-map.qiita.json');
+
+  const [devToErrors, qiitaErrors] = await Promise.all([
+    verifyDevToEntries(devToMap, devToToken),
+    verifyQiitaEntries(qiitaMap, qiitaToken)
+  ]);
+
+  const allErrors = [...devToErrors, ...qiitaErrors];
+
+  if (allErrors.length > 0) {
+    console.error('Detected remote publishing inconsistencies:');
+    for (const error of allErrors) {
+      console.error(`- ${error.file}: ${error.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('All remote articles are in sync with local markdown and post maps.');
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a workflow that verifies remote article state before merging the sync branch into main
- implement a TypeScript checker that compares local markdown to dev.to and Qiita entries
- document how to configure the sync enforcement workflow and required secrets

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d7e77fb3e88326a8612e8f03025eda