### PR TITLE
Refactor publishing scripts per platform and mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,42 +37,42 @@ changed-files: ## Show which markdown files have changed
 	@npx ts-node scripts/get_changed_files.ts
 
 draft: lint ## Create/update drafts for changed markdown files
-	@printf '$(GREEN)Creating/updating drafts for changed files...$(NC)\n'
-	@CHANGED_OUTPUT=$$(npx ts-node scripts/get_changed_files.ts | tail -2); \
-	EN_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^EN_FILES=" | cut -d'=' -f2-); \
-	JA_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^JA_FILES=" | cut -d'=' -f2-); \
-	if [ -n "$$EN_FILES" ]; then \
-		printf '$(YELLOW)Processing English files: %s$(NC)\n' "$$EN_FILES"; \
-		PUBLISH_MODE=draft npx ts-node scripts/publish_devto.ts $$EN_FILES; \
-	fi; \
-	if [ -n "$$JA_FILES" ]; then \
-		printf '$(YELLOW)Processing Japanese files: %s$(NC)\n' "$$JA_FILES"; \
-		PUBLISH_MODE=draft npx ts-node scripts/publish_qiita.ts $$JA_FILES; \
-	fi; \
-	if [ -z "$$EN_FILES" ] && [ -z "$$JA_FILES" ]; then \
-		printf '$(YELLOW)No changed markdown files found. Nothing to do.$(NC)\n'; \
-	else \
-		printf '$(GREEN)Draft operation completed!$(NC)\n'; \
-	fi
+        @printf '$(GREEN)Creating/updating drafts for changed files...$(NC)\n'
+        @CHANGED_OUTPUT=$$(npx ts-node scripts/get_changed_files.ts | tail -2); \
+        EN_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^EN_FILES=" | cut -d'=' -f2-); \
+        JA_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^JA_FILES=" | cut -d'=' -f2-); \
+        if [ -n "$$EN_FILES" ]; then \
+                printf '$(YELLOW)Processing English files: %s$(NC)\n' "$$EN_FILES"; \
+                npx ts-node scripts/draft_devto.ts $$EN_FILES; \
+        fi; \
+        if [ -n "$$JA_FILES" ]; then \
+                printf '$(YELLOW)Processing Japanese files: %s$(NC)\n' "$$JA_FILES"; \
+                npx ts-node scripts/draft_qiita.ts $$JA_FILES; \
+        fi; \
+        if [ -z "$$EN_FILES" ] && [ -z "$$JA_FILES" ]; then \
+                printf '$(YELLOW)No changed markdown files found. Nothing to do.$(NC)\n'; \
+        else \
+                printf '$(GREEN)Draft operation completed!$(NC)\n'; \
+        fi
 
 publish: lint ## Publish drafts as real articles for changed markdown files
-	@printf '$(GREEN)Publishing drafts as real articles...$(NC)\n'
-	@CHANGED_OUTPUT=$$(npx ts-node scripts/get_changed_files.ts | tail -2); \
-	EN_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^EN_FILES=" | cut -d'=' -f2-); \
-	JA_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^JA_FILES=" | cut -d'=' -f2-); \
-	if [ -n "$$EN_FILES" ]; then \
-		printf '$(YELLOW)Publishing English files: %s$(NC)\n' "$$EN_FILES"; \
-		PUBLISH_MODE=publish npx ts-node scripts/publish_devto.ts $$EN_FILES; \
-	fi; \
-	if [ -n "$$JA_FILES" ]; then \
-		printf '$(YELLOW)Publishing Japanese files: %s$(NC)\n' "$$JA_FILES"; \
-		PUBLISH_MODE=publish npx ts-node scripts/publish_qiita.ts $$JA_FILES; \
-	fi; \
-	if [ -z "$$EN_FILES" ] && [ -z "$$JA_FILES" ]; then \
-		printf '$(YELLOW)No changed markdown files found. Nothing to do.$(NC)\n'; \
-	else \
-		printf '$(GREEN)Publish operation completed!$(NC)\n'; \
-	fi
+        @printf '$(GREEN)Publishing drafts as real articles...$(NC)\n'
+        @CHANGED_OUTPUT=$$(npx ts-node scripts/get_changed_files.ts | tail -2); \
+        EN_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^EN_FILES=" | cut -d'=' -f2-); \
+        JA_FILES=$$(echo "$$CHANGED_OUTPUT" | grep "^JA_FILES=" | cut -d'=' -f2-); \
+        if [ -n "$$EN_FILES" ]; then \
+                printf '$(YELLOW)Publishing English files: %s$(NC)\n' "$$EN_FILES"; \
+                npx ts-node scripts/publish_devto.ts $$EN_FILES; \
+        fi; \
+        if [ -n "$$JA_FILES" ]; then \
+                printf '$(YELLOW)Publishing Japanese files: %s$(NC)\n' "$$JA_FILES"; \
+                npx ts-node scripts/publish_qiita.ts $$JA_FILES; \
+        fi; \
+        if [ -z "$$EN_FILES" ] && [ -z "$$JA_FILES" ]; then \
+                printf '$(YELLOW)No changed markdown files found. Nothing to do.$(NC)\n'; \
+        else \
+                printf '$(GREEN)Publish operation completed!$(NC)\n'; \
+        fi
 
 clean: ## Clean up temporary files
 	@printf '$(GREEN)Cleaning up...$(NC)\n'

--- a/scripts/draft_devto.ts
+++ b/scripts/draft_devto.ts
@@ -1,0 +1,13 @@
+import { runDevtoWorkflow } from './publish_devto';
+
+const runCli = async (): Promise<void> => {
+  const fileArgs = process.argv.slice(2);
+  await runDevtoWorkflow(fileArgs, false);
+};
+
+if (require.main === module) {
+  runCli().catch(error => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/draft_qiita.ts
+++ b/scripts/draft_qiita.ts
@@ -1,0 +1,13 @@
+import { runQiitaWorkflow } from './publish_qiita';
+
+const runCli = async (): Promise<void> => {
+  const fileArgs = process.argv.slice(2);
+  await runQiitaWorkflow(fileArgs, false);
+};
+
+if (require.main === module) {
+  runCli().catch(error => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+
+export type HttpError = Error & { status?: number };
+
+export type PlatformValue = string | string[] | undefined;
+
+export const createHttpError = (message: string, status?: number): HttpError => {
+  const error = new Error(message) as HttpError;
+  if (typeof status === 'number') {
+    error.status = status;
+  }
+  return error;
+};
+
+export const wantsPlatform = (platform: PlatformValue, target: string): boolean => {
+  if (!platform) return true;
+  const normalizedTarget = target.toLowerCase();
+  if (typeof platform === 'string') {
+    const normalized = platform.toLowerCase();
+    if (normalized === 'auto') return true;
+    return normalized
+      .split(',')
+      .map(token => token.trim())
+      .filter(Boolean)
+      .includes(normalizedTarget);
+  }
+  return platform.map(token => token.toLowerCase()).includes(normalizedTarget);
+};
+
+export const ensureArrayOfStrings = (
+  value: string[] | string | undefined,
+): string[] | undefined => {
+  if (!value) return undefined;
+  if (Array.isArray(value)) return value.map(item => String(item));
+  return value
+    .split(',')
+    .map(tag => tag.trim())
+    .filter(Boolean);
+};
+
+export const loadPostMap = <TEntry>(mapPath: string): Record<string, TEntry> => {
+  try {
+    const raw = fs.readFileSync(mapPath, 'utf-8');
+    return JSON.parse(raw) as Record<string, TEntry>;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+};
+
+export const savePostMap = <TEntry>(mapPath: string, data: Record<string, TEntry>): void => {
+  fs.writeFileSync(mapPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8');
+};


### PR DESCRIPTION
## Summary
- add dedicated draft/publish entry points for dev.to and Qiita that share common workflow logic
- rebuild the shared utilities for post map handling, tag normalization, and platform filtering
- update the Makefile workflow to invoke the new platform-specific draft and publish scripts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e6d4318083268eda0a6cc880e688