### PR TITLE
Remove redundant workflow guard

### DIFF
--- a/.github/workflows/verify-map-sync.yml
+++ b/.github/workflows/verify-map-sync.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   verify:
     name: Remote content synchronization
-    if: >-
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.ref ==
-      (vars.SYNC_BRANCH_NAME != '' && vars.SYNC_BRANCH_NAME || 'sync/articles')
     runs-on: ubuntu-latest
     env:
       TARGET_BRANCH: ${{ vars.SYNC_BRANCH_NAME != '' && vars.SYNC_BRANCH_NAME || 'sync/articles' }}


### PR DESCRIPTION
## Summary
- remove the unnecessary base-branch guard from the sync verification workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f1f743bc832690efd5c9d408affa