### PR TITLE
chore: clarify post map cleanup logging

### DIFF
--- a/scripts/getChangedFiles.ts
+++ b/scripts/getChangedFiles.ts
@@ -2,6 +2,110 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
+const CONTENT_DIRECTORIES = ['content/en/', 'content/ja/'];
+const POST_MAP_FILES = ['.posts-map.devto.json', '.posts-map.qiita.json'];
+
+const isContentMarkdown = (file: string): boolean =>
+  file.endsWith('.md') && CONTENT_DIRECTORIES.some(dir => file.startsWith(dir));
+
+const addIfContentMarkdown = (files: Set<string>, candidate: string | undefined): void => {
+  if (!candidate) {
+    return;
+  }
+
+  const normalized = candidate.trim();
+  if (!normalized) {
+    return;
+  }
+
+  if (isContentMarkdown(normalized)) {
+    files.add(normalized);
+  }
+};
+
+const collectFilesFromGitStatus = (): Set<string> => {
+  const result = new Set<string>();
+
+  const statusOutput = execSync('git status --porcelain', {
+    encoding: 'utf-8',
+    cwd: process.cwd()
+  }).trim();
+
+  if (!statusOutput) {
+    return result;
+  }
+
+  statusOutput
+    .split('\n')
+    .filter(Boolean)
+    .forEach(line => {
+      const status = line.slice(0, 2);
+      const filePart = line.slice(3);
+      if (!filePart) {
+        return;
+      }
+
+      const trimmedStatus = status.trim();
+      if (trimmedStatus.startsWith('R')) {
+        const [from, to] = filePart.split(' -> ');
+        addIfContentMarkdown(result, from);
+        addIfContentMarkdown(result, to);
+        return;
+      }
+
+      addIfContentMarkdown(result, filePart);
+    });
+
+  return result;
+};
+
+type MissingPostMapEntry = {
+  relativePath: string;
+  mapFile: string;
+};
+
+const collectMissingFilesFromPostMaps = (): MissingPostMapEntry[] => {
+  const missingEntries: MissingPostMapEntry[] = [];
+
+  for (const mapFile of POST_MAP_FILES) {
+    const mapPath = path.resolve(mapFile);
+    let raw: string;
+
+    try {
+      raw = fs.readFileSync(mapPath, 'utf-8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        continue;
+      }
+      throw error;
+    }
+
+    let entries: Record<string, unknown>;
+    try {
+      entries = JSON.parse(raw) as Record<string, unknown>;
+    } catch (error) {
+      console.warn(`Warning: Unable to parse ${mapFile}: ${(error as Error).message}`);
+      continue;
+    }
+
+    for (const relativePath of Object.keys(entries)) {
+      if (!isContentMarkdown(relativePath)) {
+        continue;
+      }
+
+      const absolutePath = path.resolve(relativePath);
+      if (!fs.existsSync(absolutePath)) {
+        missingEntries.push({
+          relativePath,
+          mapFile,
+        });
+      }
+    }
+  }
+
+  return missingEntries;
+};
+
 /**
  * Get markdown files that have changed since the last commit
  * Returns separate arrays for English and Japanese content
@@ -9,41 +113,33 @@ import path from 'path';
 const getChangedMarkdownFiles = (): { en: string[]; ja: string[] } => {
   try {
     // Get files changed in the working directory (staged + unstaged)
-    const diffOutput = execSync('git diff --name-only HEAD', {
-      encoding: 'utf-8',
-      cwd: process.cwd()
-    }).trim();
+    const changedFilesSet = collectFilesFromGitStatus();
+    const missingFromMaps = collectMissingFilesFromPostMaps();
+    const missingByRelativePath = new Map<string, Set<string>>();
 
-    // Capture untracked files (e.g., new drafts not yet staged)
-    const untrackedOutput = execSync('git ls-files --others --exclude-standard', {
-      encoding: 'utf-8',
-      cwd: process.cwd()
-    }).trim();
+    for (const { relativePath, mapFile } of missingFromMaps) {
+      changedFilesSet.add(relativePath);
 
-    const changedFilesSet = new Set<string>();
-
-    if (diffOutput) {
-      diffOutput
-        .split('\n')
-        .filter(Boolean)
-        .forEach(file => changedFilesSet.add(file));
+      if (!missingByRelativePath.has(relativePath)) {
+        missingByRelativePath.set(relativePath, new Set());
+      }
+      missingByRelativePath.get(relativePath)?.add(mapFile);
     }
 
-    if (untrackedOutput) {
-      untrackedOutput
-        .split('\n')
-        .filter(Boolean)
-        .forEach(file => changedFilesSet.add(file));
-    }
-
-    const markdownFiles = Array.from(changedFilesSet).filter(file =>
-      file.endsWith('.md') &&
-      (file.startsWith('content/en/') || file.startsWith('content/ja/')) &&
-      fs.existsSync(path.resolve(file))
-    );
+    const markdownFiles = Array.from(changedFilesSet).filter(isContentMarkdown);
 
     const enFiles = markdownFiles.filter(file => file.startsWith('content/en/'));
     const jaFiles = markdownFiles.filter(file => file.startsWith('content/ja/'));
+
+    if (missingByRelativePath.size > 0) {
+      console.log(
+        'Detected published mapping entries without source files (including drafts deleted before their first commit). They will be cleaned up:',
+      );
+      for (const [relativePath, mapFiles] of missingByRelativePath.entries()) {
+        const mapList = Array.from(mapFiles).join(', ');
+        console.log(`  ${relativePath} -> ${mapList}`);
+      }
+    }
 
     return { en: enFiles, ja: jaFiles };
   } catch (error) {

--- a/scripts/getChangedFiles.ts
+++ b/scripts/getChangedFiles.ts
@@ -1,110 +1,9 @@
-import { execSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
-
-const CONTENT_DIRECTORIES = ['content/en/', 'content/ja/'];
-const POST_MAP_FILES = ['.posts-map.devto.json', '.posts-map.qiita.json'];
-
-const isContentMarkdown = (file: string): boolean =>
-  file.endsWith('.md') && CONTENT_DIRECTORIES.some(dir => file.startsWith(dir));
-
-const addIfContentMarkdown = (files: Set<string>, candidate: string | undefined): void => {
-  if (!candidate) {
-    return;
-  }
-
-  const normalized = candidate.trim();
-  if (!normalized) {
-    return;
-  }
-
-  if (isContentMarkdown(normalized)) {
-    files.add(normalized);
-  }
-};
-
-const collectFilesFromGitStatus = (): Set<string> => {
-  const result = new Set<string>();
-
-  const statusOutput = execSync('git status --porcelain', {
-    encoding: 'utf-8',
-    cwd: process.cwd()
-  }).trim();
-
-  if (!statusOutput) {
-    return result;
-  }
-
-  statusOutput
-    .split('\n')
-    .filter(Boolean)
-    .forEach(line => {
-      const status = line.slice(0, 2);
-      const filePart = line.slice(3);
-      if (!filePart) {
-        return;
-      }
-
-      const trimmedStatus = status.trim();
-      if (trimmedStatus.startsWith('R')) {
-        const [from, to] = filePart.split(' -> ');
-        addIfContentMarkdown(result, from);
-        addIfContentMarkdown(result, to);
-        return;
-      }
-
-      addIfContentMarkdown(result, filePart);
-    });
-
-  return result;
-};
-
-type MissingPostMapEntry = {
-  relativePath: string;
-  mapFile: string;
-};
-
-const collectMissingFilesFromPostMaps = (): MissingPostMapEntry[] => {
-  const missingEntries: MissingPostMapEntry[] = [];
-
-  for (const mapFile of POST_MAP_FILES) {
-    const mapPath = path.resolve(mapFile);
-    let raw: string;
-
-    try {
-      raw = fs.readFileSync(mapPath, 'utf-8');
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        continue;
-      }
-      throw error;
-    }
-
-    let entries: Record<string, unknown>;
-    try {
-      entries = JSON.parse(raw) as Record<string, unknown>;
-    } catch (error) {
-      console.warn(`Warning: Unable to parse ${mapFile}: ${(error as Error).message}`);
-      continue;
-    }
-
-    for (const relativePath of Object.keys(entries)) {
-      if (!isContentMarkdown(relativePath)) {
-        continue;
-      }
-
-      const absolutePath = path.resolve(relativePath);
-      if (!fs.existsSync(absolutePath)) {
-        missingEntries.push({
-          relativePath,
-          mapFile,
-        });
-      }
-    }
-  }
-
-  return missingEntries;
-};
+import {
+  collectContentFilesFromGitStatus,
+  findMissingPostMapEntries,
+  isContentMarkdown,
+  splitContentFilesByLocale,
+} from './utils';
 
 /**
  * Get markdown files that have changed since the last commit
@@ -113,8 +12,8 @@ const collectMissingFilesFromPostMaps = (): MissingPostMapEntry[] => {
 const getChangedMarkdownFiles = (): { en: string[]; ja: string[] } => {
   try {
     // Get files changed in the working directory (staged + unstaged)
-    const changedFilesSet = collectFilesFromGitStatus();
-    const missingFromMaps = collectMissingFilesFromPostMaps();
+    const changedFilesSet = collectContentFilesFromGitStatus();
+    const missingFromMaps = findMissingPostMapEntries(isContentMarkdown);
     const missingByRelativePath = new Map<string, Set<string>>();
 
     for (const { relativePath, mapFile } of missingFromMaps) {
@@ -126,10 +25,7 @@ const getChangedMarkdownFiles = (): { en: string[]; ja: string[] } => {
       missingByRelativePath.get(relativePath)?.add(mapFile);
     }
 
-    const markdownFiles = Array.from(changedFilesSet).filter(isContentMarkdown);
-
-    const enFiles = markdownFiles.filter(file => file.startsWith('content/en/'));
-    const jaFiles = markdownFiles.filter(file => file.startsWith('content/ja/'));
+    const { en, ja } = splitContentFilesByLocale(changedFilesSet);
 
     if (missingByRelativePath.size > 0) {
       console.log(
@@ -141,7 +37,7 @@ const getChangedMarkdownFiles = (): { en: string[]; ja: string[] } => {
       }
     }
 
-    return { en: enFiles, ja: jaFiles };
+    return { en, ja };
   } catch (error) {
     console.error('Error detecting changed files:', (error as Error).message);
     process.exitCode = 1;
@@ -151,7 +47,7 @@ const getChangedMarkdownFiles = (): { en: string[]; ja: string[] } => {
 
 const main = (): void => {
   const changedFiles = getChangedMarkdownFiles();
-  
+
   if (changedFiles.en.length === 0 && changedFiles.ja.length === 0) {
     console.log('No changed markdown files found.');
     return;

--- a/scripts/publishingWorkflowRunner.ts
+++ b/scripts/publishingWorkflowRunner.ts
@@ -107,7 +107,7 @@ export const runPublishingWorkflow = async <
     if (!fs.existsSync(absolutePath)) {
       if (postMap[relativePath]) {
         delete postMap[relativePath];
-        console.log(`Removed stale ${adapter.platformName} mapping for ${relativePath} (file not found)`);
+        console.log(`Cleanup: removed stale ${adapter.platformName} mapping for ${relativePath} (file not found)`);
       }
       console.warn(`Skipped: ${fileArg} (file not found)`);
       continue;
@@ -133,7 +133,7 @@ export const runPublishingWorkflow = async <
       if (postMap[relativePath]) {
         delete postMap[relativePath];
         console.log(
-          `Removed stale ${adapter.platformName} mapping for ${relativePath} (platform excludes ${adapter.platformName})`,
+          `Cleanup: removed stale ${adapter.platformName} mapping for ${relativePath} (platform excludes ${adapter.platformName})`,
         );
       }
       console.log(`Skipped: ${relativePath} (platform excludes ${adapter.platformName})`);
@@ -210,7 +210,7 @@ export const runPublishingWorkflow = async <
       if (apiError.status === 404 && existingEntry) {
         delete postMap[relativePath];
         console.warn(
-          `Remote ${adapter.platformName} ${shouldPublish ? 'article' : 'draft'} for ${relativePath} is missing (404). Removed mapping so it will be recreated on the next run.`,
+          `Remote ${adapter.platformName} ${shouldPublish ? 'article' : 'draft'} for ${relativePath} is missing (404). Cleanup removed the mapping so it will be recreated on the next run.`,
         );
       }
       const statusInfo = typeof apiError.status === 'number' ? ` [HTTP ${apiError.status}]` : '';

--- a/scripts/utils/content.ts
+++ b/scripts/utils/content.ts
@@ -1,0 +1,25 @@
+export const CONTENT_DIRECTORIES = ['content/en/', 'content/ja/'];
+
+export const isContentMarkdown = (file: string): boolean =>
+  file.endsWith('.md') && CONTENT_DIRECTORIES.some(dir => file.startsWith(dir));
+
+export const splitContentFilesByLocale = (
+  files: Iterable<string>,
+): { en: string[]; ja: string[] } => {
+  const en: string[] = [];
+  const ja: string[] = [];
+
+  for (const file of files) {
+    if (!isContentMarkdown(file)) {
+      continue;
+    }
+
+    if (file.startsWith('content/en/')) {
+      en.push(file);
+    } else if (file.startsWith('content/ja/')) {
+      ja.push(file);
+    }
+  }
+
+  return { en, ja };
+};

--- a/scripts/utils/git.ts
+++ b/scripts/utils/git.ts
@@ -1,0 +1,54 @@
+import { execSync } from 'child_process';
+
+import { isContentMarkdown } from './content';
+
+const addIfContentMarkdown = (files: Set<string>, candidate: string | undefined): void => {
+  if (!candidate) {
+    return;
+  }
+
+  const normalized = candidate.trim();
+  if (!normalized) {
+    return;
+  }
+
+  if (isContentMarkdown(normalized)) {
+    files.add(normalized);
+  }
+};
+
+export const collectContentFilesFromGitStatus = (): Set<string> => {
+  const result = new Set<string>();
+
+  const statusOutput = execSync('git status --porcelain', {
+    encoding: 'utf-8',
+    cwd: process.cwd(),
+  }).trim();
+
+  if (!statusOutput) {
+    return result;
+  }
+
+  statusOutput
+    .split('\n')
+    .filter(Boolean)
+    .forEach(line => {
+      const status = line.slice(0, 2);
+      const filePart = line.slice(3);
+      if (!filePart) {
+        return;
+      }
+
+      const trimmedStatus = status.trim();
+      if (trimmedStatus.startsWith('R')) {
+        const [from, to] = filePart.split(' -> ');
+        addIfContentMarkdown(result, from);
+        addIfContentMarkdown(result, to);
+        return;
+      }
+
+      addIfContentMarkdown(result, filePart);
+    });
+
+  return result;
+};

--- a/scripts/utils/index.ts
+++ b/scripts/utils/index.ts
@@ -2,3 +2,5 @@ export * from './http';
 export * from './platform';
 export * from './frontMatter';
 export * from './postMap';
+export * from './content';
+export * from './git';

--- a/scripts/utils/postMap.ts
+++ b/scripts/utils/postMap.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 export const loadPostMap = <TEntry>(mapPath: string): Record<string, TEntry> => {
   try {
@@ -14,4 +15,46 @@ export const loadPostMap = <TEntry>(mapPath: string): Record<string, TEntry> => 
 
 export const savePostMap = <TEntry>(mapPath: string, data: Record<string, TEntry>): void => {
   fs.writeFileSync(mapPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8');
+};
+
+export const POST_MAP_FILES = ['.posts-map.devto.json', '.posts-map.qiita.json'];
+
+export type MissingPostMapEntry = {
+  relativePath: string;
+  mapFile: string;
+};
+
+export const findMissingPostMapEntries = (
+  isContentPath: (relativePath: string) => boolean,
+  postMapFiles: string[] = POST_MAP_FILES,
+): MissingPostMapEntry[] => {
+  const missingEntries: MissingPostMapEntry[] = [];
+
+  for (const mapFile of postMapFiles) {
+    const mapPath = path.resolve(mapFile);
+
+    let entries: Record<string, unknown>;
+    try {
+      entries = loadPostMap<unknown>(mapPath);
+    } catch (error) {
+      console.warn(`Warning: Unable to parse ${mapFile}: ${(error as Error).message}`);
+      continue;
+    }
+
+    for (const relativePath of Object.keys(entries)) {
+      if (!isContentPath(relativePath)) {
+        continue;
+      }
+
+      const absolutePath = path.resolve(relativePath);
+      if (!fs.existsSync(absolutePath)) {
+        missingEntries.push({
+          relativePath,
+          mapFile,
+        });
+      }
+    }
+  }
+
+  return missingEntries;
 };


### PR DESCRIPTION
## Summary
- surface which post map files reference missing markdown when queueing cleanup work
- note that the cleanup path also covers drafts deleted before their first commit so they are still detected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8b0f1e7d08326a3451d5a13e47168